### PR TITLE
Adds an option to hide seconds for localtime

### DIFF
--- a/OMGEX.js
+++ b/OMGEX.js
@@ -10,10 +10,15 @@ window.OMGEX = function (options) {
     }
     if(options.timezone) {
         let details = document.querySelector("#details");
+        if(options.timezoneNS){details.innerHTML = details.innerHTML + `<div id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: '2-digit', minute:'2-digit'})}</div>`;
+        setInterval(() => {
+            document.querySelector("#localtime").innerHTML = `<i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: '2-digit', minute:'2-digit'})}`
+        }, 1000);}
+        else{
         details.innerHTML = details.innerHTML + `<div id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone})}</div>`;
         setInterval(() => {
             document.querySelector("#localtime").innerHTML = `<i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone})}`
-        }, 500);
+        }, 500);}
     }
     if(options.terminalKonami) {
         // courtesy of https://stackoverflow.com/a/62543148


### PR DESCRIPTION
```js
<script>
window.addEventListener('load', function() {
    OMGEX({timezone: "CST6CDT", timezoneNS: true});
});
</script>
```

Gives: `11:12 AM` rather than `11:12:33 AM`

Code looks bad because I used the GitHub Web UI rather than an IDE, I shall be better for bigger PRs.