### PR TITLE
feat: Hide seconds by default and add displaySeconds configuration option

### DIFF
--- a/OMGEX.js
+++ b/OMGEX.js
@@ -24,7 +24,7 @@ window.OMGEX = function (options) {
         details.innerHTML = details.innerHTML + `<div id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}</div>`;
         setInterval(() => {
             document.querySelector("#localtime").innerHTML = `<i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}`
-        }, 500);
+        }, delay);
     }
     if(options.terminalKonami) {
         // courtesy of https://stackoverflow.com/a/62543148

--- a/OMGEX.js
+++ b/OMGEX.js
@@ -14,10 +14,16 @@ window.OMGEX = function (options) {
         details.innerHTML = details.innerHTML + `<div id="birthday"><i class="fas fa-birthday-cake"></i> ${options.birthday}</div>`;
     }
     if(options.timezone) {
+        let delay = 60000;
+        let timeDisplayOptions = { hour:"2-digit", minute:"2-digit"};
+        if(options.displaySeconds) {
+            delay = 500;
+            timeDisplayOptions.second="2-digit";
+        }
         let details = document.querySelector("#details");
-        details.innerHTML = details.innerHTML + `<div id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone})}</div>`;
+        details.innerHTML = details.innerHTML + `<div id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}</div>`;
         setInterval(() => {
-            document.querySelector("#localtime").innerHTML = `<i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone})}`
+            document.querySelector("#localtime").innerHTML = `<i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}`
         }, 500);
     }
     if(options.terminalKonami) {

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ This displays your current time underneath your birthday (if enabled) or else, o
 
 You may notice that you can also just specify for example CET, but BE WARNED! Some timezones have conflicting names, so it's recommended to just use the TZ database name.
 
+### displaySeconds
+
+Set this to `true` to display seconds in the current time (HH:MM:SS).
+
 ### terminalKonami
 
 Setting this to `true` will redirect the user to [terminal.land](https://terminal.land/) when the [Konami code](https://en.wikipedia.org/wiki/Konami_Code) is entered.


### PR DESCRIPTION
Similar to #5 but defaults to not displaying the seconds in the current time.

- Hide the seconds column from current time display by default.
- Set the current time refresh delay to 60000ms (1 minute) when not displaying seconds.
- Add `displaySeconds` configuration option, which displays the seconds in the current time when set to `true`.
- Add documentation to README.