### PR TITLE
feat: Improve styling of localtime and birthday sections in bio

### DIFF
--- a/OMGEX.js
+++ b/OMGEX.js
@@ -18,7 +18,7 @@ window.OMGEX = function (options) {
             timeDisplayOptions.second="2-digit";
         }
         let details = document.querySelector("#details");
-        details.innerHTML = details.innerHTML + `<div id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}</div>`;
+        details.innerHTML = details.innerHTML + `<span id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}</span>`;
         setInterval(() => {
             document.querySelector("#localtime").innerHTML = `<i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}`
         }, delay);

--- a/OMGEX.js
+++ b/OMGEX.js
@@ -19,12 +19,11 @@ window.OMGEX = function (options) {
         }
         let details = document.querySelector("#details");
         //if location is present, use html span tag to put localtime on the same line. Otherwise use a div.
+        let localtimeTagType="div"
         if(document.getElementById('location')){
-            details.innerHTML = details.innerHTML + `<span id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}</span>`;
-        } else {
-            details.innerHTML = details.innerHTML + `<div id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}</div>`;
+            localtimeTagType="span"
         }
-        
+        details.innerHTML = details.innerHTML + `<${localtimeTagType} id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}</${localtimeTagType}>`;
         setInterval(() => {
             document.querySelector("#localtime").innerHTML = `<i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}`
         }, delay);

--- a/OMGEX.js
+++ b/OMGEX.js
@@ -18,7 +18,13 @@ window.OMGEX = function (options) {
             timeDisplayOptions.second="2-digit";
         }
         let details = document.querySelector("#details");
-        details.innerHTML = details.innerHTML + `<span id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}</span>`;
+        //if location is present, use html span tag to put localtime on the same line. Otherwise use a div.
+        if(document.getElementById('location')){
+            details.innerHTML = details.innerHTML + `<span id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}</span>`;
+        } else {
+            details.innerHTML = details.innerHTML + `<div id="localtime"><i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}</div>`;
+        }
+        
         setInterval(() => {
             document.querySelector("#localtime").innerHTML = `<i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}`
         }, delay);

--- a/OMGEX.js
+++ b/OMGEX.js
@@ -1,5 +1,5 @@
 window.OMGEX = function (options) {
-    let version = '1.2.0';
+    let version = '1.3.0';
     if(!options || Object.keys(options).length == 0) return console.error('OMGEX: No options provided');
     if(options.zodiac) {
         let pronouns = document.querySelector("#pronouns");

--- a/OMGEX.js
+++ b/OMGEX.js
@@ -10,10 +10,6 @@ window.OMGEX = function (options) {
           	details.innerHTML = details.innerHTML + `<span id="zodiac">${options.zodiac}</span>`;
         }
     }
-    if(options.birthday) {
-        let details = document.querySelector("#details");
-        details.innerHTML = details.innerHTML + `<div id="birthday"><i class="fas fa-birthday-cake"></i> ${options.birthday}</div>`;
-    }
     if(options.timezone) {
         let delay = 60000;
         let timeDisplayOptions = { hour:"2-digit", minute:"2-digit"};
@@ -26,6 +22,10 @@ window.OMGEX = function (options) {
         setInterval(() => {
             document.querySelector("#localtime").innerHTML = `<i class="fas fa-clock"></i> ${new Date().toLocaleTimeString([], {timeZone: options.timezone, hour: timeDisplayOptions.hour, minute: timeDisplayOptions.minute, second: timeDisplayOptions.second})}`
         }, delay);
+    }
+    if(options.birthday) {
+        let details = document.querySelector("#details");
+        details.innerHTML = details.innerHTML + `<div id="birthday"><i class="fas fa-birthday-cake"></i> ${options.birthday}</div>`;
     }
     if(options.terminalKonami) {
         // courtesy of https://stackoverflow.com/a/62543148


### PR DESCRIPTION
- Uses an html `span` tag for `localtime` if the `location` div is present, which allows it to be on the same line.
- Uses the `div` tag if `location` is not present.
- Moves birthday below location and localtime in bio.

Example: 
![image](https://user-images.githubusercontent.com/3454131/142941833-9851746e-5491-4387-b2dc-7fd29199f0a2.png)
