### PR TITLE
fix: Rename verification badge class selector in popout animations

### DIFF
--- a/CSS-Snippets.md
+++ b/CSS-Snippets.md
@@ -25,7 +25,7 @@ This makes your Verification badge (if you have one), pop-out and wiggle every c
    85% { transform: scale(125%) rotate(-5deg);}
    100% { transform: rotate(0deg); }
 } 
-.fa-badge-check {
+.omg-verified {
   animation: wiggle 2.5s ease infinite;
   transition: 0.5s;
 }
@@ -41,7 +41,7 @@ This makes your Verification badge pop-out one time when the page loads.
   35% { transform: scale(190%); }
   100% { transform: scale(100%); }
 } 
-.fa-badge-check {
+.omg-verified {
   animation: popout 1.5s ease;
 }
 ```


### PR DESCRIPTION
The popout animations for the verification badge appear to be broken. It looks like the class for the badge item was renamed.

- Rename the CSS class selector (`omg-verified`) in the CSS snippets to reflect that change.
- Working example: https://dakota.omg.lol